### PR TITLE
Implement version validation and comparison in verify_reserved_state()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,7 @@ dependencies = [
  "hex",
  "rand 0.7.3",
  "secp256k1",
+ "semver",
  "serde",
  "serde_json",
  "sha3",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 hex = "0.4.3"
 secp256k1 = { version = "0.24.2", features = ["recovery", "rand-std"] }
 bincode = "1.3.3"
+semver = "1.0.0"
 
 [dev-dependencies]
 simperby-test-suite = { path = "../test-suite" }

--- a/core/src/verify.rs
+++ b/core/src/verify.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use thiserror::Error;
 
+use semver::{Version, VersionReq};
+
 #[derive(Error, Debug, Clone)]
 pub enum Error {
     #[error("invalid argument: {0}")]
@@ -245,6 +247,28 @@ impl CommitSequenceVerifier {
             return Err(Error::InvalidArgument(
                 "consensus_delegatee cannot be changed".to_string(),
             ));
+        }
+
+        let previous_version = Version::parse(&self.reserved_state.version);
+        let new_version = Version::parse(&rs.version);
+        
+        match (previous_version, new_version) {
+            (Ok(previous_version), Ok(new_version)) => {
+                if previous_version != new_version {
+                    let requirement =
+                        VersionReq::parse(&format!("> {}", previous_version)).unwrap();
+                    if !requirement.matches(&new_version) {
+                        return Err(Error::InvalidArgument(format!(
+                            "Version advances is incorrect"
+                        )));
+                    }
+                }
+            }
+            _ => {
+                return Err(Error::InvalidArgument(format!(
+                    "One or both versions are not valid SemVer"
+                )))
+            }
         }
         Ok(())
     }
@@ -1626,6 +1650,21 @@ mod test {
         assert!(csv.verify_reserved_state(&invalid_rs).is_ok());
     }
 
+<<<<<<< HEAD
+=======
+    #[test]
+    fn test_verify_reserved_state_version_advance() {
+        // configuring the test
+        let (mut _validator_keypair, reserved_state, csv) = setup_test(4);
+
+        // rendering the reserved state that is expected to be valid
+        let mut valid_rs = reserved_state.clone();
+        valid_rs.version = "1.1.0".to_string(); // set a version that is greater than the previous version
+
+        assert!(csv.verify_reserved_state(&valid_rs).is_ok());
+    }
+
+>>>>>>> 5301f36 (add checking version about semver and test code)
     #[ignore]
     #[test]
     /// Test the case where the agenda proof commit is invalid because it is extra-agenda transaction phase.

--- a/core/src/verify.rs
+++ b/core/src/verify.rs
@@ -1650,8 +1650,6 @@ mod test {
         assert!(csv.verify_reserved_state(&invalid_rs).is_ok());
     }
 
-<<<<<<< HEAD
-=======
     #[test]
     fn test_verify_reserved_state_version_advance() {
         // configuring the test
@@ -1664,7 +1662,6 @@ mod test {
         assert!(csv.verify_reserved_state(&valid_rs).is_ok());
     }
 
->>>>>>> 5301f36 (add checking version about semver and test code)
     #[ignore]
     #[test]
     /// Test the case where the agenda proof commit is invalid because it is extra-agenda transaction phase.


### PR DESCRIPTION
This commit introduces version validation and comparison in the `verify_reserved_state` function:

1. Parses the `version` field of the current and new reserved states into `semver::Version` objects.
2. If either or both versions are not valid SemVer strings, returns an error.
3. If the parsed versions are different, creates a `semver::VersionReq` object representing a version requirement of being greater than the previous version.
4. If the new version does not match this requirement, returns an error.

This ensures that the new version in the reserved state is always a valid SemVer and is always greater than the previous version, following the rules of Semantic Versioning.
